### PR TITLE
Installation fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,8 +16,7 @@ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.0.0
 jupyter
 gdown
 gensim==3.8.3
-sklearn
-gdown
+scikit-learn
 readability-lxml
 beautifulsoup4
 orjson


### PR DESCRIPTION
The 'sklearn' PyPI package is deprecated, use 'scikit-learn'.

>Preparing metadata (setup.py) ... error
>  error: subprocess-exited-with-error
>
>  × python setup.py egg_info did not run successfully.
>  │ exit code: 1
>  ╰─> [18 lines of output]
>      The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
>      rather than 'sklearn' for pip commands.